### PR TITLE
Embed description is actually 4096 characters

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 // Discord Embed limits
 // https://discord.com/developers/docs/resources/channel#embed-object-embed-limits
 export const MAX_EMBED_TITLE_LENGTH = 256
-export const MAX_EMBED_DESCRIPTION_LENGTH = 2048
+export const MAX_EMBED_DESCRIPTION_LENGTH = 4096
 export const MAX_EMBED_FIELD_NAME_LENGTH = 256
 export const MAX_EMBED_FIELD_VALUE_LENGTH = 1024
 


### PR DESCRIPTION
I saw your action being used by Bun and I realized that the action thought the embed limit was `2048` when it actually is `4096`.